### PR TITLE
Add straightforward ALeP player card automations

### DIFF
--- a/jsons/cardAutomations/basicAttachments-GENERATED.json
+++ b/jsons/cardAutomations/basicAttachments-GENERATED.json
@@ -330,6 +330,70 @@
                }
             }
          },
+         "097f57fe-63f3-4494-ab39-a907fe6f089c": {
+            "_comment": "Bree Pony",
+            "rules": {
+               "attachmentStaticPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 1 hitPoints from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/hitPoints",
+                        1
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 1 hitPoints to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/hitPoints",
+                        1
+                     ]
+                  ],
+                  "type": "passive"
+               }
+            }
+         },
          "09993d97-ebf8-4c2c-b051-2691b175a2aa": {
             "_comment": "Black Key (Boon)",
             "rules": {
@@ -3268,6 +3332,118 @@
                }
             }
          },
+         "4a2566d3-9af7-455a-bb5a-d9dafe62c636": {
+            "_comment": "Anduril",
+            "rules": {
+               "attachmentStaticPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 1 willpower from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/willpower",
+                        1
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 1 attack from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/attack",
+                        1
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 1 defense from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/defense",
+                        1
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 1 willpower to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/willpower",
+                        1
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 1 attack to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/attack",
+                        1
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 1 defense to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/defense",
+                        1
+                     ]
+                  ],
+                  "type": "passive"
+               }
+            }
+         },
          "4b36df3f-d75b-4b3a-9324-9ab31c10d7b9": {
             "_comment": "Pale Blade",
             "rules": {
@@ -4852,6 +5028,70 @@
                }
             }
          },
+         "530d5c75-bf6d-46c3-bd75-f39fb63a4d37": {
+            "_comment": "Wolf Tracks",
+            "rules": {
+               "attachmentStaticPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 10 questPoints from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/questPoints",
+                        10
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 10 questPoints to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/questPoints",
+                        10
+                     ]
+                  ],
+                  "type": "passive"
+               }
+            }
+         },
          "53c01bdc-2761-4f8f-90bc-1eedd14ca376": {
             "_comment": "Easterling Horse",
             "rules": {
@@ -5423,6 +5663,94 @@
                }
             }
          },
+         "608a1135-3b40-4189-b498-b9eff3a3f7ce": {
+            "_comment": "Brightmane",
+            "rules": {
+               "attachmentStaticPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 1 willpower from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/willpower",
+                        1
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 1 threat from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/threat",
+                        1
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 1 willpower to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/willpower",
+                        1
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 1 threat to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/threat",
+                        1
+                     ]
+                  ],
+                  "type": "passive"
+               }
+            }
+         },
          "60c7ba84-8d59-48c6-ab81-0639ab55a8bf": {
             "_comment": "Elf-stone",
             "rules": {
@@ -5545,6 +5873,70 @@
                         "INCREASE_VAL",
                         "/cardById/$THIS.parentCardId/tokens/questPoints",
                         2
+                     ]
+                  ],
+                  "type": "passive"
+               }
+            }
+         },
+         "65f15c99-d34e-4496-9ad3-4036114dc333": {
+            "_comment": "Flinthoof",
+            "rules": {
+               "attachmentStaticPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 1 attack from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/attack",
+                        1
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 1 attack to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/attack",
+                        1
                      ]
                   ],
                   "type": "passive"
@@ -6951,6 +7343,70 @@
                }
             }
          },
+         "8c504bd4-31c7-4269-a034-3007cf3cba9e": {
+            "_comment": "Let Us Sing Together",
+            "rules": {
+               "attachmentStaticPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 1 willpower from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/willpower",
+                        1
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 1 willpower to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/willpower",
+                        1
+                     ]
+                  ],
+                  "type": "passive"
+               }
+            }
+         },
          "8d99a2be-18d6-4bfb-85ab-7be54a18e6b7": {
             "_comment": "Black Mare",
             "rules": {
@@ -7330,6 +7786,70 @@
                }
             }
          },
+         "9b5119ec-5bc1-4421-8da7-1407b8279f67": {
+            "_comment": "Longing for Home",
+            "rules": {
+               "attachmentStaticPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 2 willpower to ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/willpower",
+                        2
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 2 willpower from ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/willpower",
+                        2
+                     ]
+                  ],
+                  "type": "passive"
+               }
+            }
+         },
          "9bb32f2c-29fb-43ba-b7ba-2227b28f7b58": {
             "_comment": "Elf-stone",
             "rules": {
@@ -7676,6 +8196,142 @@
                         "INCREASE_VAL",
                         "/cardById/$THIS.parentCardId/tokens/hitPoints",
                         2
+                     ]
+                  ],
+                  "type": "passive"
+               }
+            }
+         },
+         "aaea207b-e0af-4865-89c9-16985543ef9a": {
+            "_comment": "Heightened Stature (Boon)",
+            "rules": {
+               "attachmentBasicPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ],
+                     [
+                        "NOT",
+                        [
+                           "IN_STRING",
+                           "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.traits",
+                           "Hobbit."
+                        ]
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 2 hitPoints from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/hitPoints",
+                        2
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 2 hitPoints to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/hitPoints",
+                        2
+                     ]
+                  ],
+                  "type": "passive"
+               },
+               "attachmentConditionalPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ],
+                     [
+                        "IN_STRING",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.traits",
+                        "Hobbit."
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 3 hitPoints from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/hitPoints",
+                        3
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 3 hitPoints to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/hitPoints",
+                        3
                      ]
                   ],
                   "type": "passive"
@@ -8188,6 +8844,70 @@
                         "INCREASE_VAL",
                         "/cardById/$THIS.parentCardId/tokens/attack",
                         1
+                     ]
+                  ],
+                  "type": "passive"
+               }
+            }
+         },
+         "ba8a2808-f29b-404d-84dd-18d2483d9c97": {
+            "_comment": "Subdued",
+            "rules": {
+               "attachmentStaticPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 4 attack to ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/attack",
+                        4
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 4 attack from ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/attack",
+                        4
                      ]
                   ],
                   "type": "passive"
@@ -8772,6 +9492,70 @@
                      [
                         "INCREASE_VAL",
                         "/cardById/$THIS.parentCardId/tokens/attack",
+                        2
+                     ]
+                  ],
+                  "type": "passive"
+               }
+            }
+         },
+         "cc5a34e3-d7b0-4f7f-82bf-d4f4c8778dd5": {
+            "_comment": "Claw Marks",
+            "rules": {
+               "attachmentStaticPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 2 threat from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/threat",
+                        2
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 2 threat to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/threat",
                         2
                      ]
                   ],
@@ -9620,6 +10404,142 @@
                }
             }
          },
+         "ec138f38-054b-4d34-80f6-bd058c5483e7": {
+            "_comment": "Bright Mail (Boon)",
+            "rules": {
+               "attachmentBasicPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ],
+                     [
+                        "NOT",
+                        [
+                           "IN_STRING",
+                           "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.traits",
+                           "Hobbit."
+                        ]
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 1 defense from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/defense",
+                        1
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 1 defense to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/defense",
+                        1
+                     ]
+                  ],
+                  "type": "passive"
+               },
+               "attachmentConditionalPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ],
+                     [
+                        "IN_STRING",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.traits",
+                        "Hobbit."
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 2 defense from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/defense",
+                        2
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 2 defense to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/defense",
+                        2
+                     ]
+                  ],
+                  "type": "passive"
+               }
+            }
+         },
          "ee8d4a1a-6f19-4d00-a266-a4241e168cae": {
             "_comment": "Jewels of Wilder (Boon)",
             "rules": {
@@ -9686,6 +10606,70 @@
          },
          "ef014a91-c2d9-44ca-acd0-cc1a339c051f": {
             "_comment": "Tireless Ranger",
+            "rules": {
+               "attachmentStaticPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 1 defense from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/defense",
+                        1
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 1 defense to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/defense",
+                        1
+                     ]
+                  ],
+                  "type": "passive"
+               }
+            }
+         },
+         "f0ceca81-907d-4c7f-a8e3-0842bf11b80d": {
+            "_comment": "Relic of Nargothrond",
             "rules": {
                "attachmentStaticPassiveTokens": {
                   "_comment": "Add/remove tokens to the attached card.",
@@ -10001,6 +10985,70 @@
                         "DECREASE_VAL",
                         "/cardById/$THIS.parentCardId/tokens/threat",
                         2
+                     ]
+                  ],
+                  "type": "passive"
+               }
+            }
+         },
+         "f894c32c-5dfa-45f9-a5a3-122f3c171b89": {
+            "_comment": "Star-like Gem (Boon)",
+            "rules": {
+               "attachmentStaticPassiveTokens": {
+                  "_comment": "Add/remove tokens to the attached card.",
+                  "condition": [
+                     "AND",
+                     "$THIS.inPlay",
+                     [
+                        "GREATER_THAN",
+                        "$THIS.cardIndex",
+                        0
+                     ],
+                     [
+                        "EQUAL",
+                        "$THIS.currentSide",
+                        "A"
+                     ]
+                  ],
+                  "listenTo": [
+                     "/cardById/$THIS_ID/inPlay",
+                     "/cardById/$THIS_ID/currentSide",
+                     "/cardById/$THIS_ID/cardIndex"
+                  ],
+                  "offDo": [
+                     [
+                        "VAR",
+                        "$PREV_PARENT_ID",
+                        [
+                           "PREV",
+                           "$THIS.parentCardId"
+                        ]
+                     ],
+                     [
+                        "LOG",
+                        "└── ",
+                        "Removed 1 willpower from ",
+                        "$GAME.cardById.{{$PREV_PARENT_ID}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "DECREASE_VAL",
+                        "/cardById/$PREV_PARENT_ID/tokens/willpower",
+                        1
+                     ]
+                  ],
+                  "onDo": [
+                     [
+                        "LOG",
+                        "└── ",
+                        "Added 1 willpower to ",
+                        "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name",
+                        "."
+                     ],
+                     [
+                        "INCREASE_VAL",
+                        "/cardById/$THIS.parentCardId/tokens/willpower",
+                        1
                      ]
                   ],
                   "type": "passive"

--- a/jsons/cardAutomations/basicAttachments.jsonnet
+++ b/jsons/cardAutomations/basicAttachments.jsonnet
@@ -239,6 +239,28 @@ local conditionalAttachment(name, bonusList) = {
             "969e2d92-da4f-4257-8833-0cc4c19ea10d": staticAttachment("Heirloom of Iarchon (Boon)", willpower=1),
             "46b11215-59ee-46ac-8154-693ce9fff971": staticAttachment("Orders from Angmar (Boon)", defense=1),
             "a539e3f4-4387-4569-a14e-fea235ad447c": staticAttachment("Raiment of the Second Age (Boon)", attack=2, hitPoints=2),
+
+            // ALeP
+            "65f15c99-d34e-4496-9ad3-4036114dc333": staticAttachment("Flinthoof", attack=1),
+            "608a1135-3b40-4189-b498-b9eff3a3f7ce": staticAttachment("Brightmane", willpower=1, threat=1),
+            "097f57fe-63f3-4494-ab39-a907fe6f089c": staticAttachment("Bree Pony", hitPoints=1),
+            "f0ceca81-907d-4c7f-a8e3-0842bf11b80d": staticAttachment("Relic of Nargothrond", defense=1),
+            "ba8a2808-f29b-404d-84dd-18d2483d9c97": staticAttachment("Subdued", attack=-4),
+            "4a2566d3-9af7-455a-bb5a-d9dafe62c636": staticAttachment("Anduril", willpower=1, attack=1, defense=1),
+            "8c504bd4-31c7-4269-a034-3007cf3cba9e": staticAttachment("Let Us Sing Together", willpower=1),
+            "cc5a34e3-d7b0-4f7f-82bf-d4f4c8778dd5": staticAttachment("Claw Marks", threat=2),
+            "f894c32c-5dfa-45f9-a5a3-122f3c171b89": staticAttachment("Star-like Gem (Boon)", willpower=1),
+            "9b5119ec-5bc1-4421-8da7-1407b8279f67": staticAttachment("Longing for Home", willpower=-2),
+            "530d5c75-bf6d-46c3-bd75-f39fb63a4d37": staticAttachment("Wolf Tracks", questPoints=10),
+
+            "ec138f38-054b-4d34-80f6-bd058c5483e7": conditionalAttachment("Bright Mail (Boon)", [
+                {name: "attachmentBasicPassiveTokens", defense: 1, condition: [["NOT", ["IN_STRING", "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.traits", "Hobbit."]]]},
+                {name: "attachmentConditionalPassiveTokens", defense: 2, condition: [["IN_STRING", "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.traits", "Hobbit."]]}
+            ]),
+            "aaea207b-e0af-4865-89c9-16985543ef9a": conditionalAttachment("Heightened Stature (Boon)", [
+                {name: "attachmentBasicPassiveTokens", hitPoints: 2, condition: [["NOT", ["IN_STRING", "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.traits", "Hobbit."]]]},
+                {name: "attachmentConditionalPassiveTokens", hitPoints: 3, condition: [["IN_STRING", "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.traits", "Hobbit."]]}
+            ]),
         }
     }
 }

--- a/jsons/cardAutomations/playerCards.json
+++ b/jsons/cardAutomations/playerCards.json
@@ -85,6 +85,23 @@
                 ]
                 }
             },
+            "151ba48a-1efd-451e-bba0-b49fa0566596": {
+                "_comment": "Fatty Bolger (Lore, ALeP)",
+                "rules": {
+                    "fattySetup": {
+                        "_comment": "Reduce starting threat by 2.",
+                        "type": "trigger",
+                        "side": "A",
+                        "listenTo": ["/playerData/$THIS.controller/threat"],
+                        "condition": ["AND", ["EQUAL", "$GAME.roundNumber", 0], ["PREV", ["EQUAL", "$GAME.playerData.{{$THIS.controller}}.threat", 0]]],
+                        "then": [
+                            ["VAR", "$NEW_THREAT", ["SUBTRACT", "$GAME.playerData.{{$THIS.controller}}.threat", 2]],
+                            ["LOG", "└── ", "Fatty Bolger reduced starting threat by 2 to {{$NEW_THREAT}}."],
+                            ["DECREASE_VAL", "/playerData/{{$THIS.controller}}/threat", 2]
+                        ]
+                    }
+                }
+            },
             "51223bd0-ffd1-11df-a976-0801206c9005": {
                 "_comment": "Leadership Dain Ironfoot",
                 "rules": {
@@ -1028,6 +1045,24 @@
                     "A": ["DISCARD_TO_LOOK_AT_X", "$THIS", 10]
                 }
             },
+            "52f54faa-5db0-4b11-bd8b-5ee85dec5b97": {
+                "_comment":  "An Unexpected Party",
+                "ability": {
+                    "A": ["DISCARD_TO_LOOK_AT_X", "$THIS", 10]
+                }
+            },
+            "e42cb28b-0f2e-4510-962b-d96f19006be2": {
+                "_comment":  "Open the Gates",
+                "ability": {
+                    "A": ["DISCARD_TO_LOOK_AT_X", "$THIS", 5]
+                }
+            },
+            "793df72d-dce6-48fe-9d6c-24a2cf289d5f": {
+                "_comment":  "Need Brooks no Delay",
+                "ability": {
+                    "A": ["DISCARD_TO_LOOK_AT_X", "$THIS", 10]
+                }
+            },
             "439f1d94-3098-4b4a-9ceb-3b28a6eac804": {"_comment": "The Muster of Rohan", "inheritFrom": "8047c8c2-1569-428c-865e-0459c2733db3"},
             "9152834a-5355-42ba-9592-1a3c1940d1a8": {
                 "_comment": "King under the Mountain",
@@ -1331,6 +1366,10 @@
                 "_comment": "Necklace of Girion",
                 "inheritFrom": "attachedHeroGainsOneResourceInResourcePhase"
             },
+            "59201982-0c04-45a4-8675-755f90932b88": {
+                "_comment": "Bilbo's Spoons",
+                "inheritFrom": "attachedHeroGainsOneResourceInResourcePhase"
+            },
             "51223bd0-ffd1-11df-a976-0801200c9072": {
                 "_comment": "Self Preservation",
                 "ability": {
@@ -1344,6 +1383,44 @@
                             ["LOG", "└── ", "Healed 2 damage from ", "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name", "."],
                             ["TOGGLE_EXHAUST", "$THIS"],
                             ["HEAL", "$THIS.parentCardId", 2]
+                        ],
+                        ["TRUE"],
+                        ["LOG", "└── ", "The ability's conditions are not met."]
+                    ]
+                }
+            },
+            "74522565-cb89-4a49-aee0-66840fd077e5": {
+                "_comment": "Pint",
+                "ability": {
+                    "A": ["COND",
+                        ["AND", 
+                            ["GREATER_THAN", "$THIS.cardIndex", 0],
+                            ["NOT", "$THIS.exhausted"],
+                            ["GREATER_THAN", "$GAME.cardById.{{$THIS.parentCardId}}.tokens.damage", 0]
+                        ],
+                        [
+                            ["LOG", "└── ", "Healed 1 damage from ", "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name", "."],
+                            ["TOGGLE_EXHAUST", "$THIS"],
+                            ["HEAL", "$THIS.parentCardId", 1]
+                        ],
+                        ["TRUE"],
+                        ["LOG", "└── ", "The ability's conditions are not met."]
+                    ]
+                }
+            },
+            "aaea207b-e0af-4865-89c9-16985543ef9a": {
+                "_comment": "Heightened Stature (Boon)",
+                "ability": {
+                    "A": ["COND",
+                        ["AND", 
+                            ["GREATER_THAN", "$THIS.cardIndex", 0],
+                            ["NOT", "$THIS.exhausted"],
+                            ["GREATER_THAN", "$GAME.cardById.{{$THIS.parentCardId}}.tokens.damage", 0]
+                        ],
+                        [
+                            ["LOG", "└── ", "Healed 1 damage from ", "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name", "."],
+                            ["TOGGLE_EXHAUST", "$THIS"],
+                            ["HEAL", "$THIS.parentCardId", 1]
                         ],
                         ["TRUE"],
                         ["LOG", "└── ", "The ability's conditions are not met."]
@@ -1424,6 +1501,10 @@
             },
             "3892b2e4-358c-42af-b5be-2f54d252ea2a": {
                 "_comment": "Leader of Men (Boon)",
+                "inheritFrom": "exhaustToAddOneResourceToAttachedCharacter"
+            },
+            "bcc1ca6e-5bd7-48ec-99ee-bbec6e78e7ed": {
+                "_comment": "Beorn's Welcome",
                 "inheritFrom": "exhaustToAddOneResourceToAttachedCharacter"
             },
             "51223bd0-ffd1-11df-a976-0801200c9045": {
@@ -1507,6 +1588,14 @@
                 "_comment": "Shadowfax",
                 "inheritFrom": "exhaustToReadyAttachedCharacter"
             },
+            "4a2566d3-9af7-455a-bb5a-d9dafe62c636": {
+                "_comment": "Anduril (ALep)",
+                "inheritFrom": "exhaustToReadyAttachedCharacter"
+            },
+            "77721e76-80a6-41b0-a71a-9cd533954250": {
+                "_comment": "Onward Into Battle",
+                "inheritFrom": "exhaustToReadyAttachedCharacter"
+            },
             "51223bd0-ffd1-11df-a976-1801204c9024": {
                 "_comment": "Cram",
                 "ability": {
@@ -1553,6 +1642,21 @@
             },
             "9fa0e4f8-4abf-4552-bb46-94c4b1f0bc15": {"_comment": "Lembas", "inheritFrom": "f86ea37a-d70d-4ff2-ac36-2a0ff1f7ffa9"},
             "28938e58-2900-45d9-b9d9-7d05b7088cc9": {"_comment": "Lembas", "inheritFrom": "f86ea37a-d70d-4ff2-ac36-2a0ff1f7ffa9"},
+            "f0ceca81-907d-4c7f-a8e3-0842bf11b80d": {
+                "_comment": "Relic of Nargothrond",
+                "ability": {
+                    "A": ["COND",
+                        ["GREATER_THAN", "$THIS.cardIndex", 0],
+                        [
+                            ["LOG", "└── ", "Discarded ", "$THIS.currentFace.name", " to add 2 defense to ", "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name", " until the end of the round."],
+                            ["ADD_TEMP_TOKEN", "round", "$THIS.parentCardId", "defense", 2],
+                            ["ACTION_LIST", "discardCard"]
+                        ],
+                        ["TRUE"],
+                        ["LOG", "└── ", "The ability's conditions are not met."]
+                    ]
+                }
+            },
             "29b76593-0ef3-410b-aa85-1c282d4b1582": {
                 "_comment": "Captain of Gondor",
                 "ability": {
@@ -1751,6 +1855,32 @@
             "59cd2c5f-1986-4065-ad2c-8423d6b200e2": {
                 "_comment": "Sword-thain",
                 "inheritFrom": "parentCardGainsHeroType"
+            },
+            "a4a86a9e-050a-4df4-9403-04bf68a7dc99": {
+                "_comment": "Word of Persuasion",
+                "rules": {
+                    "makeIntoAlly": {
+                        "type": "passive",
+                        "autoRun": {
+                            "status": "promptYN",
+                            "promptPlayerI": "$THIS.controller",
+                            "promptMessage": "Apply the new card type to {{$THIS.parentCard.sides.A.name}}?"
+                        },
+                        "listenTo": ["/cardById/$THIS_ID/cardIndex"],
+                        "condition": ["GREATER_THAN", "$THIS.cardIndex", 0],
+                        "onDo": [
+                            ["VAR", "$ALIAS", ["GET_ALIAS", "$THIS.controller"]],
+                            ["LOG", "{{$ALIAS}} gave the ally type to {{$THIS.parentCard.sides.A.name}}."],
+                            ["SET", "/cardById/$THIS.parentCardId/sides/A/type", "Ally"]
+                        ],
+                        "offDo": [
+                            ["VAR", "$ALIAS", ["GET_ALIAS", "$THIS.controller"]],
+                            ["VAR", "$PREV_PARENT", ["PREV", "$THIS.parentCard"]],
+                            ["LOG", "{{$ALIAS}} removed the ally type from {{$PREV_PARENT.sides.A.name}}."],
+                            ["SET", "/cardById/{{$PREV_PARENT.id}}/sides/A/type", "Enemy"]
+                        ]
+                    }
+                }
             }
         }
     }

--- a/jsons/cardAutomations/playerCards.json
+++ b/jsons/cardAutomations/playerCards.json
@@ -1893,15 +1893,10 @@
                 "rules": {
                     "makeIntoAlly": {
                         "type": "passive",
-                        "autoRun": {
-                            "status": "promptYN",
-                            "promptPlayerI": "$THIS.controller",
-                            "promptMessage": "Apply the new card type to {{$THIS.parentCard.sides.A.name}}?"
-                        },
                         "listenTo": ["/cardById/$THIS_ID/cardIndex"],
                         "condition": ["GREATER_THAN", "$THIS.cardIndex", 0],
                         "onDo": [
-                            ["VAR", "$ALIAS", ["GET_ALIAS", "$THIS.controller"]],
+                            ["VAR", "$ALIAS", ["GET_ALIAS", ["PREV", "$THIS.controller"]]],
                             ["LOG", "{{$ALIAS}} gave the ally type to {{$THIS.parentCard.sides.A.name}}."],
                             ["SET", "/cardById/$THIS.parentCardId/sides/A/type", "Ally"]
                         ],

--- a/jsons/cardAutomations/playerCards.json
+++ b/jsons/cardAutomations/playerCards.json
@@ -995,6 +995,14 @@
                     "A": ["DISCARD_TO_LOOK_AT_X", "$THIS", 5]
                 }
             },
+            "51223bd0-ffd1-11df-a976-0801212c9010": {
+                "_comment": "Daeron's Runes",
+                "ability": {
+                    "A": ["DISCARD_TO_LOOK_AT_X", "$THIS", 2]
+                }
+            },
+            "d8729719-5d37-48c2-9bf6-8d2c8d579901": {"_comment": "Daeron's Runes", "inheritFrom": "51223bd0-ffd1-11df-a976-0801212c9010"},
+            "37863571-be66-46b1-82d3-d21f4f0e653c": {"_comment": "Daeron's Runes", "inheritFrom": "51223bd0-ffd1-11df-a976-0801212c9010"},
             "51e0054c-c48d-4fc7-9737-30bf12d4b52a": {
                 "_comment": "Westfold Horse-breeder",
                 "ability": {
@@ -1314,6 +1322,30 @@
                         "then": [
                             ["VAR", "$ALIAS", ["GET_ALIAS", "$THIS.controller"]],
                             ["LOG", "{{$ALIAS}} added 1 resource to Treebeard."],
+                            ["INCREASE_VAL", "/cardById/$THIS_ID/tokens/resource", 1]
+                        ]
+                    }
+                }
+            },
+            "51223bd0-ffd1-11df-a976-0801203c9003": {
+                "_comment": "Radagast",
+                "rules": {
+                    "radagastResource": {
+                        "type": "trigger",
+                        "autoRun": {
+                            "status": "prompt",
+                            "promptPlayerI": "$THIS.controller",
+                            "promptMessage": "Add 1 resource to Radagast?"
+                        },
+                        "listenTo": ["/stepId"],
+                        "condition": ["AND", 
+                            ["EQUAL", "$GAME.stepId", "1.R"], 
+                            ["EQUAL", "$THIS.currentSide", "A"],
+                            ["EQUAL", "$THIS.inPlay", true]
+                        ],
+                        "then": [
+                            ["VAR", "$ALIAS", ["GET_ALIAS", "$THIS.controller"]],
+                            ["LOG", "{{$ALIAS}} added 1 resource to Radagast."],
                             ["INCREASE_VAL", "/cardById/$THIS_ID/tokens/resource", 1]
                         ]
                     }
@@ -1648,8 +1680,8 @@
                     "A": ["COND",
                         ["GREATER_THAN", "$THIS.cardIndex", 0],
                         [
-                            ["LOG", "└── ", "Discarded ", "$THIS.currentFace.name", " to add 2 defense to ", "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name", " until the end of the round."],
-                            ["ADD_TEMP_TOKEN", "round", "$THIS.parentCardId", "defense", 2],
+                            ["LOG", "└── ", "Discarded ", "$THIS.currentFace.name", " to add 2 defense to ", "$GAME.cardById.{{$THIS.parentCardId}}.currentFace.name", " until the end of the phase."],
+                            ["ADD_TEMP_TOKEN", "phase", "$THIS.parentCardId", "defense", 2],
                             ["ACTION_LIST", "discardCard"]
                         ],
                         ["TRUE"],

--- a/jsons/cardAutomations/playerCards.json
+++ b/jsons/cardAutomations/playerCards.json
@@ -780,7 +780,7 @@
                 }
             },
             "8d6a15a8-e363-46bb-8e49-0af45a1ea0d1": {
-                "_comment": "Galadriel",
+                "_comment": "Galadriel (Hero)",
                 "ability": {
                     "A": ["COND",
                         ["AND", 
@@ -815,7 +815,7 @@
                     ]
                 }
             },
-            "8ccfbcf2-676c-4e24-ab5e-fa479343ab39": {"_comment": "Galadriel", "inheritFrom": "8d6a15a8-e363-46bb-8e49-0af45a1ea0d1"},
+            "8ccfbcf2-676c-4e24-ab5e-fa479343ab39": {"_comment": "Galadriel (Hero)", "inheritFrom": "8d6a15a8-e363-46bb-8e49-0af45a1ea0d1"},
             "51223bd0-ffd1-11df-a976-0801200c9012": {
                 "_comment": "Beravor",
                 "ability": {
@@ -1225,6 +1225,7 @@
                             ["EQUAL", "$THIS.inPlay", true]
                         ],
                         "then": [
+                            ["DEFINE", "$ACTIVE_CARD_ID", "$THIS_ID"],
                             ["ACTION_LIST", "discardCard"]
                         ]
                     }
@@ -1328,7 +1329,7 @@
                 }
             },
             "51223bd0-ffd1-11df-a976-0801203c9003": {
-                "_comment": "Radagast",
+                "_comment": "Radagast (Ally)",
                 "rules": {
                     "radagastResource": {
                         "type": "trigger",
@@ -1621,7 +1622,7 @@
                 "inheritFrom": "exhaustToReadyAttachedCharacter"
             },
             "4a2566d3-9af7-455a-bb5a-d9dafe62c636": {
-                "_comment": "Anduril (ALep)",
+                "_comment": "Anduril (ALeP)",
                 "inheritFrom": "exhaustToReadyAttachedCharacter"
             },
             "77721e76-80a6-41b0-a71a-9cd533954250": {


### PR DESCRIPTION
Depends on #10 so merge that first.

Adds automations for many ALeP player cards. I haven't actually tested these locally yet since I haven't set up the combined TSV for upload yet (and I don't have the TSV for the new AP anyway) but they are pretty much all just copies of existing automations so shouldn't be much to go wrong anyway.