### PR TITLE
Fix some broken hotkeys, improve some wordings

### DIFF
--- a/jsons/actionLists.json
+++ b/jsons/actionLists.json
@@ -43,7 +43,7 @@
             ["VAR", "$REVEAL_FACEDOWN", true],
             ["ACTION_LIST", "revealSecondary"]
         ],
-        "hotkeyE": [
+        "revealEncounter": [
             ["COND", 
                 ["AND", "$GAME.gameStepAutomation", 
                     ["OR",
@@ -71,7 +71,7 @@
                     ["VAR", "$CARD_ID", ["GET_CARD_ID", "sharedEncounterDeck2", 0, 0]],
                     ["MOVE_CARD", "$CARD_ID", "sharedStagingArea", -1, 0], 
                     ["COND",
-                        "$REVEAL_FACEDOWN",
+                        ["DEFINED", "$REVEAL_FACEDOWN"],
                         ["SET", "/cardById/$CARD_ID/currentSide", "B"]
                     ],
                     ["LOG", "{{$ALIAS_N}} revealed {{$GAME.cardById.$CARD_ID.currentFace.name}}."]
@@ -138,6 +138,7 @@
             ]
         ],
         "mulligan": [
+            ["LOG", "$ALIAS_N", " performed a mulligan."],
             ["VAR", "$HAND_GROUP_ID", ["JOIN_STRING", "$PLAYER_N", "Hand"]],
             ["VAR", "$DECK_GROUP_ID", ["JOIN_STRING", "$PLAYER_N", "Deck"]],
             ["VAR", "$HAND_SIZE", ["LENGTH", "$GAME.groupById.$HAND_GROUP_ID.stackIds"]],
@@ -398,7 +399,11 @@
                     true,
                     [
                         ["MOVE_STACK", ["GET_STACK_ID", "sharedQuestDeck", 0], "sharedMainQuest", 0],
-                        ["LOG", "$ALIAS_N", " advanced the quest."]
+                        ["LOG", "$ALIAS_N", " advanced the quest."],
+                        ["COND",
+                            ["NOT_EQUAL", "$ACTIVE_FACE.victoryPoints", null],
+                            ["PROMPT", "$PLAYER_N", "victoryDisplay", "$ACTIVE_CARD_ID"]
+                        ]
                     ]
                 ]
             ]

--- a/jsons/hotkeys.json
+++ b/jsons/hotkeys.json
@@ -13,12 +13,12 @@
         ],
         "game": [
             {"key": "D", "actionList": "drawCard", "label": "id:drawACard"},
-            {"key": "E", "actionList": "hotkeyE", "label": "id:revealEncounterCard"},
+            {"key": "E", "actionList": "revealEncounter", "label": "id:revealEncounterCard"},
             {"key": "Shift+E", "actionList": "revealEncounterFacedown", "label": "id:revealFacedownEncounterCard"},
-            {"key": "K", "actionList": "revealSecondaryFaceup", "label": "id:revealCardFromSecondEncounterDeck"},
+            {"key": "K", "actionList": "revealSecondary", "label": "id:revealCardFromSecondEncounterDeck"},
+            {"key": "Shift+K", "actionList": "revealSecondaryFacedown", "label": "id:revealFacedownCardFromSecondEncounterDeck"},
             {"key": "M", "actionList": "toggleMap", "label": "id:toggleTheMap"},
             {"key": ",", "actionList": "toggleExtra", "label": "id:toggleExtra"},
-            {"key": "Shift+K", "actionList": "revealSecondaryFacedown", "label": "id:revealFacedownCardFromSecondEncounterDeck"},
             {"key": "Shift+M", "actionList": "mulligan", "label": "id:mulligan"},
             {"key": "W", "actionList": ["DO_ADVANCE_BUTTON"], "label": "id:advanceThroughRoundStopAtTriggers"},
             {"key": "Z", "actionList": ["RESOLVE_QUEST"], "label": "id:resolveTheQuest"},
@@ -30,14 +30,13 @@
             {"key": "Shift+S", "actionList": "skipToDealShadowsStep", "label": "id:dealAllShadowCards"},
             {"key": "Shift+X", "actionList": "skipToDiscardShadowsStep", "label": "id:discardAllShadowCards"},
             {"key": "U", "actionList": "increaseThreat", "label": "id:raiseThreatBy1"},
-            {"key": "J", "actionList": "decreaseThreat", "label": "id:raiseThreatBy1"},
+            {"key": "J", "actionList": "decreaseThreat", "label": "id:reduceThreatBy1"},
             {"key": "Shift+U", "actionList": "raiseAllThreat", "label": "id:raiseThreatBy1ForAllPlayers"},
             {"key": "Shift+J", "actionList": "reduceAllThreat", "label": "id:reduceThreatBy1ForAllPlayers"},
-            {"key": "Shift+D", "actionList": "drawNextPlayer", "label": "id:drawCardOnBehalfOfNextEmptySeat"}
+            {"key": "Shift+D", "actionList": "drawNextSeat", "label": "id:drawCardOnBehalfOfNextEmptySeat"}
         ],
         "card": [
             {"key": "A", "actionList": "hotkeyA", "label": "id:exhaustReadyIfLocationMakeActive"},
-            {"key": "C", "actionList": "detach", "label": "id:detach"},
             {"key": "F", "actionList": "flipCard", "label": "id:flip"},
             {"key": "C", "actionList": "detach", "label": "id:detach"},
             {"key": "H", "actionList": "shuffleIntoDeck", "label": "id:shuffleIntoOwnerSDeck"},
@@ -47,7 +46,7 @@
             {"key": "V", "actionList": "addToVictoryDisplay", "label": "id:addToVictoryDisplay"},
             {"key": "Q", "actionList": "toggleCommit", "label": "id:commitUncommitFromQuest"},
             {"key": "X", "actionList": "discardCard", "label": "id:discardOrAdvance"},
-            {"key": "Shift+C", "actionList": "discardOtherCardsInStack", "label": "id:discardAllOtherCardsInThisCardSStack"},
+            //{"key": "Shift+C", "actionList": "discardOtherCardsInStack", "label": "id:discardAllOtherCardsInThisCardSStack"},
             {"key": "B", "actionList": "sendToBack", "label": "id:sendAttachmentToBackOfStack"},
             {"key": "Shift+T", "actionList": "swapWithTop", "label": "id:swapWithTop"}
         ]

--- a/jsons/labels.json
+++ b/jsons/labels.json
@@ -33,20 +33,17 @@
         "readyForNextPlanning": {
             "English": "Ready For Next Planning"
         },
-        "skipToRefreshPhase": {
-            "English": "Skip To Refresh Phase"
-        },
         "toggleEngagedWithEachPlayer": {
             "English": "Toggle Engaged With Each Player"
         },
-        "skipToDealShadowsStep": {
-            "English": "Skip To Deal Shadows Step"
-        },
         "skipToNextPlanningPhase": {
-            "English": "Skip To Next Planning Phase"
+            "English": "Skip to Next Planning Phase"
         },
-        "skipToNextRefreshPhase": {
-            "English": "Skip To Refresh Phase"
+        "skipToDealShadowsStep": {
+            "English": "Skip to Deal Shadows Step"
+        },
+        "skipToRefreshPhase": {
+            "English": "Skip to Refresh Phase"
         },
         "advanceThroughRoundStopAtTriggers": {
             "English": "Advance Through Round"
@@ -170,6 +167,9 @@
         "raiseThreatBy1": {
             "English": "Raise threat by 1",
             "Chinese": "威胁增加1"
+        },
+        "reduceThreatBy1": {
+            "English": "Reduce threat by 1"
         },
         "saveGame": {
             "English": "Save game",
@@ -1236,7 +1236,7 @@
             "Chinese": "探险牌组"
         },
         "sharedQuestDeck2": {
-            "English": "Quest Deck",
+            "English": "Quest Deck 2",
             "Chinese": "探险牌组"
         },
         "sharedActiveLocation": {
@@ -1260,35 +1260,35 @@
             "Chinese": "遭遇牌组3"
         },
         "sharedExtra1": {
-            "English": "Extra1",
+            "English": "Extra 1",
             "Chinese": "额外区域 1"
         },
         "sharedExtra2": {
-            "English": "Extra2",
+            "English": "Extra 2",
             "Chinese": "额外区域 2"
         },
         "sharedExtra3": {
-            "English": "Extra3",
+            "English": "Extra 3",
             "Chinese": "额外区域 3"
         },
         "sharedExtra4": {
-            "English": "Extra4",
+            "English": "Extra 4",
             "Chinese": "额外区域 4"
         },
         "sharedExtra5": {
-            "English": "Extra5",
+            "English": "Extra 5",
             "Chinese": "额外区域 5"
         },
         "sharedExtra6": {
-            "English": "Extra6",
+            "English": "Extra 6",
             "Chinese": "额外区域 6"
         },
         "sharedExtra7": {
-            "English": "Extra7",
+            "English": "Extra 7",
             "Chinese": "额外区域 7"
         },
         "sharedExtra8": {
-            "English": "Extra8",
+            "English": "Extra 8",
             "Chinese": "额外区域 8"
         },
         "damage": {
@@ -1636,19 +1636,19 @@
             "Chinese": "主要探险"
         },
         "player1Deck2": {
-            "English": "Player1 Deck2",
+            "English": "Player 1 Deck 2",
             "Chinese": "玩家 1 第二牌库"
         },
         "player2Deck2": {
-            "English": "Player2 Deck2",
+            "English": "Player 2 Deck 2",
             "Chinese": "玩家 2 第二牌库"
         },
         "player3Deck2": {
-            "English": "Player3 Deck2",
+            "English": "Player 3 Deck 2",
             "Chinese": "玩家 3 第二牌库"
         },
         "player4Deck2": {
-            "English": "Player4 Deck2",
+            "English": "Player 4 Deck 2",
             "Chinese": "玩家 4 第二牌库"
         },
         "exhaustReady": {

--- a/jsons/playerCardAutomation.json
+++ b/jsons/playerCardAutomation.json
@@ -984,8 +984,7 @@
                     "A": ["LOOK_AT_X", "{{$THIS.controller}}Deck", 10]
                 }
             },
-            "0567c2df-677c-4529-985a-54621088fe58": {"_comment": "Westfold Horse-breeder", "inheritFrom": "51e0054c-c48d-4fc7-9737-30bf12d4b52a"
-},
+            "0567c2df-677c-4529-985a-54621088fe58": {"_comment": "Westfold Horse-breeder", "inheritFrom": "51e0054c-c48d-4fc7-9737-30bf12d4b52a"},
             "51223bd0-ffd1-11df-a976-0801201c9008": {
                 "_comment": "The Eagles Are Coming",
                 "ability": {
@@ -1216,7 +1215,7 @@
                         "then": [
                             ["VAR", "$ALIAS", ["GET_ALIAS", "$THIS.controller"]],
                             ["LOG", "{{$ALIAS}} drew 1 additional card from Ori."],
-                            ["DRAW_CARD"]
+                            ["DRAW_CARD", 1, "$THIS.controller"]
                         ]
                     }
                 }
@@ -1237,7 +1236,7 @@
                         "then": [
                             ["VAR", "$ALIAS", ["GET_ALIAS", "$THIS.controller"]],
                             ["LOG", "├── ", "{{$ALIAS}} drew 1 additional card from Stone of Elostirion."],
-                            ["DRAW_CARD"]
+                            ["DRAW_CARD", 1, "$THIS.controller"]
                         ]
                     }
                 }

--- a/jsons/prompts.json
+++ b/jsons/prompts.json
@@ -79,11 +79,12 @@
                     "label": "Yes",
                     "hotkey": "Y",
                     "code": [
+                        ["LOG", "{{$ALIAS_N}} added ", "$GAME.cardById.{{$CARD_ID}}.currentFace.name", " to the victory display."],
                         ["MOVE_CARD", "$CARD_ID", "sharedVictory", 0]
                     ]
                 },
                 {
-                    "label": "NO",
+                    "label": "No",
                     "hotkey": "N"
                 }
             ]


### PR DESCRIPTION
There were a number of non-functioning hotkeys so I've gone through each of them and checked that they actually work now.

User-facing changes:
- Added log when user performs mulligan
- Added "Move to victory display" prompt for quest cards if they have victory points (e.g. Flight to Moria)
- Fixed revealSecondary and revealSecondaryFacedown hotkeys not functioning
- Fixed decreaseThreat hotkey having wrong label
- Fixed drawNextSeat hotkey not functioning
- Fixed detach hotkey appearing twice in hotkey list
- Removed discardOtherCardsInStack hotkey from hotkey list as there's currently no implementation for it
- Removed capitalisation of "To" in some hotkey labels
- Changed "Extra1" and "Player1 Deck2" labels to "Extra 1" and "Player 1 Deck 2" for consistency
- Added log to victory display prompt
- Changed "NO" label to "No" in victory display prompt for consistency