### PR TITLE
Fix: The automation for Keen as Lances doesn't add it to the Victory Display

### DIFF
--- a/jsons/playerCardPrompts.json
+++ b/jsons/playerCardPrompts.json
@@ -972,7 +972,8 @@
                     "hotkey": "2",
                     "code": [
                         ["LOG", "└── ", ["GET_ALIAS", "$CONTROLLER"], " drew 3 cards."],
-                        ["DRAW_CARD", 3, "$CONTROLLER"]
+                        ["DRAW_CARD", 3, "$CONTROLLER"],
+                        ["MOVE_CARD", "$CARD.id", "sharedVictory", 0]
                     ]
                 },
                 {
@@ -980,7 +981,8 @@
                     "hotkey": "3",
                     "code": [
                         ["LOG", "└── ", ["GET_ALIAS", "$CONTROLLER"], " reduced their threat by 4."],
-                        ["DECREASE_VAL", "/playerData/{{$CONTROLLER}}/threat", 4]
+                        ["DECREASE_VAL", "/playerData/{{$CONTROLLER}}/threat", 4],
+                        ["MOVE_CARD", "$CARD.id", "sharedVictory", 0]
                     ]
                 },
                 {


### PR DESCRIPTION
## Automated bug fix

Generated by [DragnCards bot](https://dragncards.com) using Claude Code.

**Bug report:** https://discord.com/channels/863466461792043068/1164413308347101244/1500102532951703652

**Description:**
> The automation for Keen as Lances doesn't add it to the Victory Display
