### PR TITLE
Fix: Hello, The Battle of Carn Dum. The first stage of the scenario prevents

### DIFF
--- a/jsons/questAutomation.json
+++ b/jsons/questAutomation.json
@@ -117,6 +117,22 @@
                     }
                 }
             },
+            "b1662195-6d46-474c-9ee9-ccbf14c7b70e": {
+                "_comment": "The Clutches of Carn Dûm",
+                "rules": {
+                    "clutchesOfCarnDumShadows": {
+                        "_comment": "While side B (The Clutches of Carn Dûm) is active, prevent shadow cards from being auto-discarded by rotating them to -29 instead of -30 so the discard automation skips them",
+                        "type": "whileInPlay",
+                        "side": "B",
+                        "listenTo": ["/cardById/*/rotation"],
+                        "condition": ["EQUAL", "$TARGET.rotation", -30],
+                        "onDo": [
+                            ["SET", "/cardById/$TARGET_ID/rotation", -29]
+                        ],
+                        "offDo": []
+                    }
+                }
+            },
             "5c8e7eab-3899-489e-a801-3ac34b77f62f": {
                 "_comment": "The Nine are Abroad",
                 "rules": {


### PR DESCRIPTION
## Automated bug fix

Generated by [DragnCards bot](https://dragncards.com) using Claude Code.

**Bug report:** https://discord.com/channels/863466461792043068/1164413308347101244/1473042896096854157

**Description:**
> Hello, The Battle of Carn Dum. The first stage of the scenario prevents from dicarding unresolved shadow cards at the end of the combat phase however dragnscard keeps discarding these cards. I can't skip this macro at the end of the combat phase. Any tips how to bypass it?
