### PR TITLE
Fix: Error in LotR Living Card Game triggered by [1/derrio]: Variable $CORNER

### DIFF
--- a/jsons/prompts.json
+++ b/jsons/prompts.json
@@ -483,9 +483,9 @@
                         ["SHUFFLE_GROUP", "sharedEncounterDeck"],
                         ["VAR", "$CORNER_CARD", ["ONE_CARD", "$C", ["AND", ["EQUAL", "$C.row", 2], ["EQUAL", "$C.col", 0]]]],
                         ["SET", "/cardById/$CORNER_CARD.id/tokens/attack", 1],
-                        ["COND", ["GREATER_THAN", "$GAME.numPlayers", 1], ["SET", "/cardById/$CORNER_CARD_ID/tokens/defense", 1]],
-                        ["COND", ["GREATER_THAN", "$GAME.numPlayers", 2], ["SET", "/cardById/$CORNER_CARD_ID/tokens/hitPoints", 1]],
-                        ["COND", ["GREATER_THAN", "$GAME.numPlayers", 3], ["SET", "/cardById/$CORNER_CARD_ID/tokens/time", 1]],
+                        ["COND", ["GREATER_THAN", "$GAME.numPlayers", 1], ["SET", "/cardById/$CORNER_CARD.id/tokens/defense", 1]],
+                        ["COND", ["GREATER_THAN", "$GAME.numPlayers", 2], ["SET", "/cardById/$CORNER_CARD.id/tokens/hitPoints", 1]],
+                        ["COND", ["GREATER_THAN", "$GAME.numPlayers", 3], ["SET", "/cardById/$CORNER_CARD.id/tokens/time", 1]],
                         ["VAR", "$CORNER_CARD", ["ONE_CARD", "$C", ["AND", ["EQUAL", "$C.row", 0], ["EQUAL", "$C.col", 3]]]],
                         ["SET", "/cardById/$CORNER_CARD.id/tokens/threat", 1]
                     ]   


### PR DESCRIPTION
## Automated bug fix

Generated by [DragnCards bot](https://dragncards.com) using Claude Code.

**Bug report:** https://discord.com/channels/863466461792043068/1164413308347101244/1504665194092171284

**Description:**
> Error in LotR Living Card Game triggered by [1/derrio]: Variable $CORNER_CARD_ID is undefined. Trace: ["Prompt response: Setup of prompt glitteringSetup", "index 1", "index 1", "index 16", "COND", "index 0 (then)", "SET", "path", "/cardById/$CORNER_CARD_ID/tokens/defense", "LIST", "index 1"]
