### PR TITLE
Fix: The single-player automated setup for NM To Catch an Orc does not automa

### DIFF
--- a/jsons/prompts.json
+++ b/jsons/prompts.json
@@ -201,11 +201,18 @@
                                     ]
                                 ]],
                                 ["VAR", "$MUGASH_CARDS", ["CONCAT_LISTS", "$MUGASH_CARD", "$MUGASH_GUARDS"]],
+                                ["VAR", "$VIGILANT_ORCS", ["FILTER_CARDS", "$C",
+                                    ["AND",
+                                        ["EQUAL", "$C.groupId", "sharedSetAside"],
+                                        ["EQUAL", "$C.sides.A.name", "Vigilant Orc"]
+                                    ]
+                                ]],
                                 ["VAR", "$PLAYER_INDEX", 0],
                                 ["LOG", "{{$ALIAS_N}} created the secondary player decks."],
                                 ["LOG", "{{$ALIAS_N}} moved the Mugash cards to the secondary player decks."],
                                 ["FOR_EACH_VAL", "$PLAYER_I", ["SHUFFLE_LIST", "$PLAYER_ORDER"], [
                                     ["MOVE_CARD", "$MUGASH_CARDS.[$PLAYER_INDEX].id", "{{$PLAYER_I}}Deck2", 0],
+                                    ["COND", ["GREATER_THAN", ["LENGTH", "$VIGILANT_ORCS"], "$PLAYER_INDEX"], ["MOVE_CARD", "$VIGILANT_ORCS.[$PLAYER_INDEX].id", "{{$PLAYER_I}}Deck2", 0]],
                                     ["MOVE_STACKS", "{{$PLAYER_I}}Deck", "{{$PLAYER_I}}Deck2", 20, "shuffle"],
                                     ["SHOW_PLAYER_DECK_2", "$PLAYER_I", true],
                                     ["INCREASE_VAR", "$PLAYER_INDEX", 1]


### PR DESCRIPTION
## Automated bug fix

Generated by [DragnCards bot](https://dragncards.com) using Claude Code.

**Bug report:** https://discord.com/channels/863466461792043068/1164413308347101244/1508445369250484286

**Description:**
> The single-player automated setup for NM To Catch an Orc does not automatically shuffle a Vigilant Orc into the out-of-play deck w/Mugash. Not a big deal (it's easy to drag and drop it in), but I thought I'd report it.
